### PR TITLE
Change some methods to properties

### DIFF
--- a/UK Mod Manager/API/UKAPI.cs
+++ b/UK Mod Manager/API/UKAPI.cs
@@ -22,6 +22,28 @@ namespace UMM
         private static List<string> disableCybergrindReasons = new List<string>();
 
         /// <summary>
+        /// Returns whether or not leaderboard submissions are allowed.
+        /// </summary>
+        public static bool CanSubmitLeaderboardScore {
+            get {
+                Debug.Log("Not submitting cybergrind");
+                foreach(string reason in disableCybergrindReasons)
+                    Debug.Log(" reason: " + reason);
+                return disableCybergrindReasons.Count == 0;
+            }
+		}
+
+        /// <summary>
+        /// Returns a clone of all found <see cref="ModInformation"/> instances.
+        /// </summary>
+        public static ModInformation[] AllModInfoClone => UltraModManager.foundMods.ToArray().Clone() as ModInformation[];
+
+        /// <summary>
+        /// Returns a clone of all loaded <see cref="ModInformation"/> instances.
+        /// </summary>
+        public static ModInformation[] AllLoadedModInfoClone => UltraModManager.allLoadedMods.ToArray().Clone() as ModInformation[];
+
+        /// <summary>
         /// Initializes the API by loading the save file and common asset bundle
         /// </summary>
         internal static IEnumerator InitializeAPI()
@@ -84,16 +106,8 @@ namespace UMM
                 Debug.Log("Tried to remove cg reason " + reason + " but could not find it!");
         }
 
-        /// <summary>
-        /// Gets whether or not CyberGrind submissions are allowed
-        /// </summary>
-        public static bool ShouldSubmitCyberGrindScore()
-        {
-            Debug.Log("Not submitting cybergrind");
-            foreach (string reason in disableCybergrindReasons)
-                Debug.Log(" reason: " + reason);
-            return disableCybergrindReasons.Count == 0;
-        }
+        [Obsolete("Use CanSubmitLeaderboardScore instead.")]
+        public static bool ShouldSubmitCyberGrindScore() => CanSubmitLeaderboardScore;
 
         /// <summary>
         /// Tries to create a Ultrakill asset load request from ULTRAKILL_Data/StreamingAssets/common, note that this request has to be awaited
@@ -125,23 +139,11 @@ namespace UMM
             return commonBundle.LoadAsset(name);
         }
 
-        /// <summary>
-        /// Gets all mod information, loaded or not
-        /// </summary>
-        /// <returns>Returns an array of all found mods</returns>
-        public static ModInformation[] GetAllModInformation()
-        {
-            return UltraModManager.foundMods.ToArray().Clone() as ModInformation[];
-        }
+        [Obsolete("Use AllModInfoClone instead.")]
+        public static ModInformation[] GetAllModInformation() => AllModInfoClone;
 
-        /// <summary>
-        /// Gets all loaded mod information
-        /// </summary>
-        /// <returns>Returns an array of all loaded mods</returns>
-        public static ModInformation[] GetAllLoadedModInformation()
-        {
-            return UltraModManager.allLoadedMods.ToArray().Clone() as ModInformation[];
-        }
+        [Obsolete("Use AllLoadedModInfoClone instead.")]
+        public static ModInformation[] GetAllLoadedModInformation() => AllLoadedModInfoClone;
 
         /// <summary>
         /// Restarts Ultrakill

--- a/UK Mod Manager/Harmony Patches/Cybergrind Patches.cs
+++ b/UK Mod Manager/Harmony Patches/Cybergrind Patches.cs
@@ -15,7 +15,7 @@ namespace UMM.HarmonyPatches
     {
         public static bool Prefix()
         {
-            bool flag = UKAPI.ShouldSubmitCyberGrindScore();
+            bool flag = UKAPI.CanSubmitLeaderboardScore;
             if (!flag)
                 StatsManager.Instance.majorUsed = true;
             Debug.Log("Flag is " + flag);
@@ -28,7 +28,7 @@ namespace UMM.HarmonyPatches
     {
         public static bool Prefix()
         {
-            bool flag = UKAPI.ShouldSubmitCyberGrindScore();
+            bool flag = UKAPI.CanSubmitLeaderboardScore;
             Debug.Log("Should submit cybergrind score is " + flag);
             return flag;
         }

--- a/UK Mod Manager/Harmony Patches/Mod UI Patches.cs
+++ b/UK Mod Manager/Harmony Patches/Mod UI Patches.cs
@@ -101,7 +101,7 @@ namespace UMM.HarmonyPatches
                 GameObject.Destroy(hoverText.GetComponent<Button>());
                 hoverText.SetActive(false);
 
-                ModInformation[] information = UKAPI.GetAllModInformation();
+                ModInformation[] information = UKAPI.AllModInfoClone;
                 if (information.Length > 0)
                 {
                     Array.Sort(information);


### PR DESCRIPTION
Some methods in the code are better suited as properties. These are:
- `UKAPI.ShouldSubmitCyberGrindScore`
- `UKAPI.GetAllModInformation`
- `UKAPI.GetAllLoadedModInformation`

All of these methods have been changed to properties (for backwards compatibility reasons, the methods still exist). Their names and XML docs have also been changed to be better/more accurate.