### PR TITLE
Better logging/exception throwing

### DIFF
--- a/UK Mod Manager/API/UKAPI.cs
+++ b/UK Mod Manager/API/UKAPI.cs
@@ -46,7 +46,7 @@ namespace UMM
             if (triedLoadingBundle)
                 yield break;
             SaveFileHandler.LoadData();
-            Debug.Log("UMM: Trying to load common asset bundle from " + Environment.CurrentDirectory + "\\ULTRAKILL_Data\\StreamingAssets\\common");
+            Plugin.logger.LogInfo("Trying to load common asset bundle from " + Environment.CurrentDirectory + "\\ULTRAKILL_Data\\StreamingAssets\\common");
             AssetBundleCreateRequest request = AssetBundle.LoadFromFileAsync(Environment.CurrentDirectory + "\\ULTRAKILL_Data\\StreamingAssets\\common");
             yield return request;
             int attempts = 1;
@@ -55,7 +55,7 @@ namespace UMM
                 yield return new WaitForSeconds(0.2f); // why 0.2? I dunno I just chose it man
                 if (attempts >= 5)
                 {
-                    Debug.Log("UMM: Could not load common asset bundle");
+                    Plugin.logger.LogInfo("Could not load common asset bundle");
                     triedLoadingBundle = true;
                     yield break;
                 }
@@ -64,7 +64,7 @@ namespace UMM
                 attempts++;
             }
 
-            Debug.Log("Loaded common asset bundle");
+            Plugin.logger.LogInfo("Loaded common asset bundle");
             commonBundle = request.assetBundle;
             triedLoadingBundle = true;
             UltraModManager.InitializeManager();
@@ -104,7 +104,7 @@ namespace UMM
             if (disableCybergrindReasons.Contains(reason))
                 disableCybergrindReasons.Remove(reason);
             else
-                Debug.Log("Tried to remove cg reason " + reason + " but could not find it!");
+                Plugin.logger.LogError("Tried to remove cg reason " + reason + " but could not find it!");
         }
 
         [Obsolete("Use CanSubmitLeaderboardScore instead.")]
@@ -119,7 +119,7 @@ namespace UMM
         {
             if (commonBundle == null)
             {
-                Debug.LogError("UMM: Could not load asset " + name + " due to the common asset bundle not being loaded.");
+                Plugin.logger.LogError("UMM: Could not load asset " + name + " due to the common asset bundle not being loaded.");
                 return null;
             }
             return commonBundle.LoadAssetAsync(name);
@@ -134,7 +134,7 @@ namespace UMM
         {
             if (commonBundle == null)
             {
-                Debug.LogError("UMM: Could not load asset " + name + " due to the common asset bundle not being loaded.");
+                Plugin.logger.LogError("UMM: Could not load asset " + name + " due to the common asset bundle not being loaded.");
                 return null;
             }
             return commonBundle.LoadAsset(name);
@@ -152,7 +152,7 @@ namespace UMM
         public static void Restart() // thanks https://gitlab.com/vtolvr-mods/ModLoader/-/blob/release/Launcher/Program.cs
         {
             Application.Quit();
-            Debug.Log("Restarting Ultrakill!");
+            Plugin.logger.LogMessage("Restarting Ultrakill!");
 
             var psi = new System.Diagnostics.ProcessStartInfo
             {
@@ -187,7 +187,7 @@ namespace UMM
             {
                 path = Assembly.GetExecutingAssembly().Location;
                 path = path.Substring(0, path.LastIndexOf("\\")) + "\\persistent mod data.json";
-                Debug.Log("Trying to mod persistent data file from " + path);
+                Plugin.logger.LogInfo("Trying to mod persistent data file from " + path);
                 FileInfo fInfo = new FileInfo(path);
                 if (fInfo.Exists)
                 {
@@ -201,7 +201,7 @@ namespace UMM
                 }
                 else
                 {
-                    Debug.Log("Couldn't find a save file, making one now");
+                    Plugin.logger.LogInfo("Couldn't find a save file, making one now");
                     fInfo.Create();
                 }
             }
@@ -209,7 +209,7 @@ namespace UMM
             internal static void DumpFile()
             {
                 FileInfo fInfo = new FileInfo(path);
-                Debug.Log("Dumping mod persistent data file to " + path);
+                Plugin.logger.LogInfo("Dumping mod persistent data file to " + path);
                 File.WriteAllText(fInfo.FullName, JsonConvert.SerializeObject(savedData));
             }
 

--- a/UK Mod Manager/API/UKMod.cs
+++ b/UK Mod Manager/API/UKMod.cs
@@ -19,7 +19,7 @@ namespace UMM
             object[] customAttributes = type.GetCustomAttributes(typeof(UKPlugin), false);
             if (customAttributes.Length == 0)
             {
-                throw new NullReferenceException("Could not find the metadata (UKPlugin) to UKMod " + type.Name);
+                throw new Exception("Could not find the metadata (UKPlugin) to UKMod " + type.Name);
             }
             metaData = (UKPlugin)customAttributes[0];
         }

--- a/UK Mod Manager/Harmony Patches/Cybergrind Patches.cs
+++ b/UK Mod Manager/Harmony Patches/Cybergrind Patches.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using UMM.Loader;
 using UnityEngine;
 
 namespace UMM.HarmonyPatches
@@ -11,7 +12,7 @@ namespace UMM.HarmonyPatches
             bool flag = UKAPI.CanSubmitCybergrindScore;
             if (!flag)
                 StatsManager.Instance.majorUsed = true;
-            Debug.Log("Should submit Cybergrind score is " + flag);
+            Plugin.logger.LogDebug("Should submit Cybergrind score is " + flag);
             return true;
         }
     }
@@ -22,7 +23,7 @@ namespace UMM.HarmonyPatches
         private static bool Prefix()
         {
             bool flag = UKAPI.CanSubmitCybergrindScore;
-            Debug.Log("Should submit cybergrind score is " + flag);
+            Plugin.logger.LogDebug("Should submit cybergrind score is " + flag);
             return flag;
         }
     }

--- a/UK Mod Manager/Plugin.cs
+++ b/UK Mod Manager/Plugin.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using BepInEx;
+using BepInEx.Logging;
 using HarmonyLib;
 
 namespace UMM.Loader
@@ -8,11 +9,15 @@ namespace UMM.Loader
     public class Plugin : BaseUnityPlugin
     {
         private static bool initialized = false;
+
+        internal static ManualLogSource logger;
+
         private void Start()
         {
             if (!initialized)
             {
-                Debug.Log("UMM initializing!");
+                logger = Logger;
+                logger.LogMessage("UMM initializing!");
                 new Harmony("umm.mainManager").PatchAll();
                 StartCoroutine(UKAPI.InitializeAPI());
                 StartCoroutine(VersionHandler.CheckVersion());

--- a/UK Mod Manager/UltraModManager.cs
+++ b/UK Mod Manager/UltraModManager.cs
@@ -91,7 +91,7 @@ namespace UMM.Loader
             object[] customAttributes = t.GetCustomAttributes(typeof(BepInPlugin), true);
             if (customAttributes.Length == 0)
             {
-                throw new NullReferenceException("Could not find the metadata (BepInPlugin) to BaseUnityPlugin " + t.FullName);
+                throw new Exception("Could not find the metadata (BepInPlugin) to BaseUnityPlugin " + t.FullName);
             }
             return (BepInPlugin)customAttributes[0];
         }
@@ -101,7 +101,7 @@ namespace UMM.Loader
             object[] customAttributes = t.GetCustomAttributes(typeof(UKPlugin), true);
             if (customAttributes.Length == 0)
             {
-                throw new NullReferenceException("Could not find the metadata (UKPlugin) to UKMod " + t.FullName);
+                throw new Exception("Could not find the metadata (UKPlugin) to UKMod " + t.FullName);
             }
             return (UKPlugin)customAttributes[0];
         }

--- a/UK Mod Manager/UltraModManager.cs
+++ b/UK Mod Manager/UltraModManager.cs
@@ -20,7 +20,7 @@ namespace UMM.Loader
         {
             if (!initialized)
             {
-                Debug.Log("Beginning UltraModManager");
+                Plugin.logger.LogMessage("Beginning UltraModManager");
                 initialized = true;
                 CollectAssemblies();
                 LoadOnStart();
@@ -35,7 +35,7 @@ namespace UMM.Loader
                     LoadFromAssembly(info);
             else
                 Directory.CreateDirectory(Environment.CurrentDirectory + @"\BepInEx\UMM Mods\");
-            Debug.Log("Found " + foundMods.Count + " mods that can be loaded.");
+            Plugin.logger.LogInfo("Found " + foundMods.Count + " mods that can be loaded.");
         }
 
         private static void LoadOnStart()
@@ -49,7 +49,7 @@ namespace UMM.Loader
                     loadedMods++;
                 }
             }
-            Debug.Log("Loaded " + loadedMods + " mods on start");
+            Plugin.logger.LogInfo("Loaded " + loadedMods + " mods on start");
         }
 
         public static void LoadFromAssembly(FileInfo fInfo)
@@ -72,7 +72,7 @@ namespace UMM.Loader
                         info = new ModInformation(type, ModInformation.ModType.BepInPlugin);
                     else
                         continue;
-                    Debug.Log("Adding mod info " + fInfo.FullName + " " + type.Name);
+                    Plugin.logger.LogInfo("Adding mod info " + fInfo.FullName + " " + type.Name);
                     foundMods.Add(info);
                     object retrievedData = UKAPI.SaveFileHandler.RetrieveModData("LoadOnStart", info.modName);
                     if (retrievedData != null && bool.Parse(retrievedData.ToString()))
@@ -81,8 +81,7 @@ namespace UMM.Loader
             }
             catch (Exception e)
             {
-                Debug.Log("Caught exception while trying to load assembly " + fInfo.FullName);
-                Debug.Log(e.ToString());
+                Plugin.logger.LogError("Caught exception while trying to load assembly " + fInfo.FullName + ": " + e.ToString());
                 return;
             }
         }
@@ -113,7 +112,7 @@ namespace UMM.Loader
             UKMod newMod = null;
             try
             {
-                Debug.Log("Trying to load mod " + info.modName);
+                Plugin.logger.LogInfo("Trying to load mod " + info.modName);
                 if (info.mod.IsSubclassOf(typeof(BaseUnityPlugin)))
                 {
                     GameObject.DontDestroyOnLoad(modObject);
@@ -121,7 +120,7 @@ namespace UMM.Loader
                     modObject.AddComponent(info.mod);
                     allLoadedMods.Add(info);
                     modObject.SetActive(true);
-                    Debug.Log("Loaded BepInExPlugin " + info.modName);
+                    Plugin.logger.LogInfo("Loaded BepInExPlugin " + info.modName);
                     return;
                 }
                 if (!info.mod.IsSubclassOf(typeof(UKMod)))
@@ -136,12 +135,11 @@ namespace UMM.Loader
                     UKAPI.DisableCyberGrindSubmission(info.modName);
                 modObject.SetActive(true);
                 newMod.OnModLoaded();
-                Debug.Log("Loaded UKMod " + info.modName);
+                Plugin.logger.LogInfo("Loaded UKMod " + info.modName);
             }
             catch (Exception e)
             {
-                Debug.LogError("Caught exception while trying to load modinformation " + info.modName);
-                Debug.LogException(e);
+                Plugin.logger.LogError("Caught exception while trying to load modinformation " + info.modName + ": " + e.ToString());
                 if (modObject != null)
                 {
                     if (newMod != null)
@@ -155,7 +153,7 @@ namespace UMM.Loader
         {
             if (modObjects.ContainsKey(info) && info.supportsUnloading)
             {
-                Debug.Log("Trying to unload mod " + info.modName);
+                Plugin.logger.LogInfo("Trying to unload mod " + info.modName);
                 GameObject modObject = modObjects[info];
                 UKMod mod = modObject.GetComponent<UKMod>();
                 mod.OnModUnloaded.Invoke();
@@ -165,7 +163,7 @@ namespace UMM.Loader
                 GameObject.Destroy(modObject);
                 if (!UltraModManager.GetUKMetaData(info.mod).allowCyberGrindSubmission)
                     UKAPI.RemoveDisableCyberGrindReason(info.modName);
-                Debug.Log("Successfully unloaded mod " + info.modName);
+                Plugin.logger.LogInfo("Successfully unloaded mod " + info.modName);
             }
         }
     }

--- a/UK Mod Manager/UltraModManager.csproj
+++ b/UK Mod Manager/UltraModManager.csproj
@@ -132,6 +132,9 @@
   <ItemGroup>
     <ModDlls Include="$(OutDir)/$(AssemblyName).dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="UltraModManager.csproj.user" />
+  </ItemGroup>
   <Target Name="WarnBeforeBuild" BeforeTargets="BeforeBuild">
     <Error Condition="!Exists($(ULTRAKILLPath))" Text="ULTRAKILLPath not set, create a .csproj.user file that sets this property to compile" />
   </Target>

--- a/UK Mod Manager/VersionHandler.cs
+++ b/UK Mod Manager/VersionHandler.cs
@@ -10,18 +10,18 @@ namespace UMM.Loader
         public const string VERSION = "0.4.4"; // Should this be hardcoded? No it should not be
         public static  IEnumerator CheckVersion()
         {
-            Debug.Log("UMM: Trying to get verison.");
+            Plugin.logger.LogInfo("Trying to get verison.");
             using (UnityWebRequest www = UnityWebRequest.Get("https://api.github.com/repos/Temperz87/ultra-mod-manager/tags"))
             {
                 yield return www.SendWebRequest();
                 if (www == null)
                 {
-                    Debug.Log("UMM: WWW was null when checking version!");
+                    Plugin.logger.LogError("WWW was null when checking version!");
                     yield break;
                 }
                 if (www.isNetworkError)
                 {
-                    Debug.Log("UMM: Couldn't get the version from url, " + www.error);
+                    Plugin.logger.LogError("Couldn't get the version from url: " + www.error);
                     yield break;
                 }
                 string text = www.downloadHandler.text;
@@ -30,7 +30,7 @@ namespace UMM.Loader
                 string latestVersion = jObjects[0].Value<string>("name");
                 if (latestVersion != VERSION)
                 {
-                    Debug.Log("UMM: New version found: " + latestVersion + " while the current version is " + VERSION);
+                    Plugin.logger.LogWarning("New version found: " + latestVersion + " while the current version is " + VERSION);
                     UltraModManager.outdated = true;
                     UltraModManager.newLoaderVersion = latestVersion;
                 }


### PR DESCRIPTION
Changed all `Debug.Log` and similar function calls to use the BepInEx log system. This means that logs will go from looking like this:
```
[Unity Log] blah blah blah
```
To this:
```
[UMM] blah blah blah
```
Also, I changed throwing `NullReferenceException` to throw different exception types, since the contexts in which `NullReferenceException` was thrown had nothing to do with null references.