### PR TITLE
Changed mod dependency system, works similar to BepInEx's system

### DIFF
--- a/TestMod/TestMod.csproj
+++ b/TestMod/TestMod.csproj
@@ -35,14 +35,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\0Harmony.dll</HintPath>
+      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="BCE">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\BCE.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -56,58 +53,31 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UMM">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UMM.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.InputSystem">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\Unity.InputSystem.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEditor">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEditor.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AIModule">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.AIModule.dll</HintPath>
+      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.ImageConversionModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.IMGUIModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.InputLegacyModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.ParticleSystemModule">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.PhysicsModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.UI.dll</HintPath>
+      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -119,11 +89,11 @@
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestTextureModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/TestMod/TestMod.csproj
+++ b/TestMod/TestMod.csproj
@@ -35,11 +35,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="BCE">
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\BCE.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -53,31 +56,58 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="UMM">
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UMM.dll</HintPath>
+    </Reference>
+    <Reference Include="Unity.InputSystem">
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\Unity.InputSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEditor">
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEditor.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.AIModule">
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.AIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.AnimationModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.AssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.AudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.ImageConversionModule">
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.ImageConversionModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.IMGUIModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.InputLegacyModule">
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.InputLegacyModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.ParticleSystemModule">
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.PhysicsModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -89,11 +119,11 @@
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestAudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>D:\Vidjagames\Steam\steamapps\common\ULTRAKILL\ULTRAKILL_Data\Managed\UnityEngine.UnityWebRequestModule.dll</HintPath>
+      <HintPath>E:\GitHub\UltrakitLibrary\UltrakitLibrary\lib\UnityEngine.UnityWebRequestModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestTextureModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/UK Mod Manager/API/UKAPI.cs
+++ b/UK Mod Manager/API/UKAPI.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using UMM.Loader;
 using Newtonsoft.Json;
 using UnityEngine.SceneManagement;
+using System.Linq;
 
 namespace UMM
 {
@@ -31,12 +32,12 @@ namespace UMM
         /// <summary>
         /// Returns a clone of all found <see cref="ModInformation"/> instances.
         /// </summary>
-        public static ModInformation[] AllModInfoClone => UltraModManager.foundMods.ToArray().Clone() as ModInformation[];
+        public static Dictionary<string, ModInformation> AllModInfoClone => UltraModManager.foundMods.ToDictionary(entry => entry.Key, entry => entry.Value);
 
         /// <summary>
         /// Returns a clone of all loaded <see cref="ModInformation"/> instances.
         /// </summary>
-        public static ModInformation[] AllLoadedModInfoClone => UltraModManager.allLoadedMods.ToArray().Clone() as ModInformation[];
+        public static Dictionary<string, ModInformation> AllLoadedModInfoClone => UltraModManager.allLoadedMods.ToDictionary(entry => entry.Key, entry => entry.Value);
 
         /// <summary>
         /// Initializes the API by loading the save file and common asset bundle
@@ -141,10 +142,10 @@ namespace UMM
         }
 
         [Obsolete("Use AllModInfoClone instead.")]
-        public static ModInformation[] GetAllModInformation() => AllModInfoClone;
+        public static Dictionary<string, ModInformation> GetAllModInformation() => AllModInfoClone;
 
         [Obsolete("Use AllLoadedModInfoClone instead.")]
-        public static ModInformation[] GetAllLoadedModInformation() => AllLoadedModInfoClone;
+        public static Dictionary<string, ModInformation> GetAllLoadedModInformation() => AllLoadedModInfoClone;
 
         /// <summary>
         /// Restarts Ultrakill

--- a/UK Mod Manager/API/UKDependency.cs
+++ b/UK Mod Manager/API/UKDependency.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace UMM
+{
+    public class UKDependency : Attribute
+    {
+        public string GUID;
+        public Version MinimumVersion;
+
+        public UKDependency(string GUID, string MinimumVersion)
+        {
+            this.GUID = GUID;
+            this.MinimumVersion = Version.Parse(MinimumVersion);
+        }
+    }
+}

--- a/UK Mod Manager/API/UKPlugin.cs
+++ b/UK Mod Manager/API/UKPlugin.cs
@@ -4,14 +4,16 @@ namespace UMM
 {
     public class UKPlugin : Attribute
     {
+        public string GUID;
         public string name;
         public string version;
         public string description;
         public bool allowCyberGrindSubmission;
         public bool unloadingSupported;
 
-        public UKPlugin(string name, string version, string description, bool allowCyberGrindSubmission, bool supportsUnloading)
+        public UKPlugin(string GUID, string name, string version, string description, bool allowCyberGrindSubmission, bool supportsUnloading)
         {
+            this.GUID = GUID;
             this.name = name;
             this.version = version;
             this.description = description;

--- a/UK Mod Manager/Harmony Patches/Mod UI Patches.cs
+++ b/UK Mod Manager/Harmony Patches/Mod UI Patches.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 using UnityEngine.UI;
 using UMM.Loader;
 using UnityEngine.EventSystems;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace UMM.HarmonyPatches
 {
@@ -96,7 +98,7 @@ namespace UMM.HarmonyPatches
                 GameObject.Destroy(hoverText.GetComponent<Button>());
                 hoverText.SetActive(false);
 
-                ModInformation[] information = UKAPI.AllModInfoClone;
+                ModInformation[] information = UKAPI.AllModInfoClone.Values.ToArray();
                 if (information.Length > 0)
                 {
                     Array.Sort(information);

--- a/UK Mod Manager/ModInformation.cs
+++ b/UK Mod Manager/ModInformation.cs
@@ -8,12 +8,14 @@ namespace UMM
     {
         public ModType modType;
         public Type mod;
+        public string GUID;
         public string modName;
         public string modDescription;
-        public string modVersion;
+        public Version modVersion;
         public bool supportsUnloading;
         public bool loadOnStart;
         public bool loaded;
+        public Dependency[] dependencies;
 
         public ModInformation(Type mod, ModType modType)
         {
@@ -24,17 +26,21 @@ namespace UMM
             if (modType == ModType.BepInPlugin)
             {
                 BepInPlugin metaData = UltraModManager.GetBepinMetaData(mod);
+                GUID = metaData.GUID;
                 modName = metaData.Name;
-                modVersion = metaData.Version.ToString();
+                modVersion = metaData.Version;
                 modDescription = "Mod unloading and descriptions are not supported by BepInEx plugins.";
+                dependencies = UltraModManager.GetBepinDependencies(mod);
             }
             else if (modType == ModType.UKMod)
             {
                 UKPlugin metaData = UltraModManager.GetUKMetaData(mod);
+                GUID = metaData.GUID;
                 modName = metaData.name;
                 modDescription = metaData.description;
-                modVersion = metaData.version;
+                modVersion = Version.Parse(metaData.version);
                 supportsUnloading = metaData.unloadingSupported;
+                dependencies = UltraModManager.GetUKModDependencies(mod);
             }
         }
 
@@ -55,8 +61,8 @@ namespace UMM
         {
             if (!loaded)
             {
-                UltraModManager.LoadMod(this);
                 loaded = true;
+                UltraModManager.LoadMod(this);
             }
         }
 
@@ -64,8 +70,8 @@ namespace UMM
         {
             if (loaded && supportsUnloading)
             {
+                loaded = false;
                 UltraModManager.UnloadMod(this);
-                loaded = false; 
             }
         }
 
@@ -74,5 +80,11 @@ namespace UMM
             UKMod,
             BepInPlugin
         }
+    }
+
+    public class Dependency
+    {
+        public string GUID;
+        public Version MinimumVersion;
     }
 }

--- a/UK Mod Manager/Properties/AssemblyInfo.cs
+++ b/UK Mod Manager/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("UK Sound Replacement")]
+[assembly: AssemblyTitle("UltraModManager")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("UK Sound Replacement")]
+[assembly: AssemblyProduct("UltraModManager")]
 [assembly: AssemblyCopyright("Copyright ©  2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/UK Mod Manager/UltraModManager.cs
+++ b/UK Mod Manager/UltraModManager.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Reflection;
 using UnityEngine;
 
@@ -9,8 +10,8 @@ namespace UMM.Loader
 {
     public static class UltraModManager
     {
-        public static List<ModInformation> foundMods = new List<ModInformation>();
-        public static List<ModInformation> allLoadedMods = new List<ModInformation>();
+        public static Dictionary<string, ModInformation> foundMods = new Dictionary<string, ModInformation>();
+        public static Dictionary<string, ModInformation> allLoadedMods = new Dictionary<string, ModInformation>();
         public static bool outdated = false;
         public static string newLoaderVersion = "";
         private static bool initialized = false;
@@ -41,7 +42,7 @@ namespace UMM.Loader
         private static void LoadOnStart()
         {
             int loadedMods = 0;
-            foreach (ModInformation info in foundMods)
+            foreach (ModInformation info in foundMods.Values)
             {
                 if (info.loadOnStart)
                 {
@@ -54,12 +55,6 @@ namespace UMM.Loader
 
         public static void LoadFromAssembly(FileInfo fInfo)
         {
-            DirectoryInfo dInfo = new DirectoryInfo(fInfo.DirectoryName + "\\dependencies");
-            if (dInfo.Exists) // this solution is a hack i am well aware
-            {
-                foreach (FileInfo info in dInfo.GetFiles("*.dll", SearchOption.AllDirectories))
-                    Assembly.LoadFile(info.FullName);
-            }
             try
             {
                 Assembly ass = Assembly.LoadFile(fInfo.FullName);
@@ -73,7 +68,7 @@ namespace UMM.Loader
                     else
                         continue;
                     Debug.Log("Adding mod info " + fInfo.FullName + " " + type.Name);
-                    foundMods.Add(info);
+                    foundMods.Add(info.GUID, info);
                     object retrievedData = UKAPI.SaveFileHandler.RetrieveModData("LoadOnStart", info.modName);
                     if (retrievedData != null && bool.Parse(retrievedData.ToString()))
                         info.loadOnStart = true;
@@ -107,8 +102,53 @@ namespace UMM.Loader
             return (UKPlugin)customAttributes[0];
         }
 
+        internal static Dependency[] GetBepinDependencies(Type t)
+        {
+            BepInDependency[] customAttributes = (BepInDependency[])t.GetCustomAttributes(typeof(BepInDependency), true);
+            List<Dependency> dependencies = new List<Dependency>();
+            foreach (BepInDependency attribute in customAttributes)
+            {
+                dependencies.Add(new Dependency() { GUID = attribute.DependencyGUID, MinimumVersion = attribute.MinimumVersion });
+            }
+            return dependencies.ToArray();
+        }
+
+        internal static Dependency[] GetUKModDependencies(Type t)
+        {
+            UKDependency[] customAttributes = (UKDependency[])t.GetCustomAttributes(typeof(UKDependency), true);
+            List<Dependency> dependencies = new List<Dependency>();
+            foreach (UKDependency attribute in customAttributes)
+            {
+                dependencies.Add(new Dependency() { GUID = attribute.GUID, MinimumVersion = attribute.MinimumVersion });
+            }
+            return dependencies.ToArray();
+        }
+
         public static void LoadMod(ModInformation info)
         {
+            if (allLoadedMods.ContainsKey(info.GUID)) return;
+            foreach (Dependency dependency in info.dependencies)
+            {
+                if (foundMods.ContainsKey(dependency.GUID))
+                {
+                    if (foundMods[dependency.GUID].modVersion >= dependency.MinimumVersion)
+                    {
+                        LoadMod(foundMods[dependency.GUID]);
+                    }
+                    else
+                    {
+                        info.loaded = false;
+                        Debug.LogError($"Required dependency ({foundMods[dependency.GUID].modName}, version {foundMods[dependency.GUID].modVersion}) did not meet version requirements of {info.modName} (minimum version {dependency.MinimumVersion})");
+                        return;
+                    }
+                }
+                else
+                {
+                    info.loaded = false;
+                    Debug.LogError($"Required dependency ({dependency.GUID}) of {info.modName} not found.");
+                    return;
+                }
+            }
             GameObject modObject = GameObject.Instantiate(new GameObject());
             UKMod newMod = null;
             try
@@ -119,7 +159,7 @@ namespace UMM.Loader
                     GameObject.DontDestroyOnLoad(modObject);
                     modObject.SetActive(false);
                     modObject.AddComponent(info.mod);
-                    allLoadedMods.Add(info);
+                    allLoadedMods.Add(info.GUID, info);
                     modObject.SetActive(true);
                     Debug.Log("Loaded BepInExPlugin " + info.modName);
                     return;
@@ -129,7 +169,7 @@ namespace UMM.Loader
                 GameObject.DontDestroyOnLoad(modObject);
                 modObject.SetActive(false);
                 newMod = modObject.AddComponent(info.mod) as UKMod;
-                allLoadedMods.Add(info);
+                allLoadedMods.Add(info.GUID, info);
                 modObjects.Add(info, modObject);
                 UKPlugin metaData = UltraModManager.GetUKMetaData(info.mod);
                 if (!metaData.allowCyberGrindSubmission)
@@ -161,7 +201,7 @@ namespace UMM.Loader
                 mod.OnModUnloaded.Invoke();
                 mod.OnModUnload();
                 modObjects.Remove(info);
-                allLoadedMods.Remove(info);
+                allLoadedMods.Remove(info.GUID);
                 GameObject.Destroy(modObject);
                 if (!UltraModManager.GetUKMetaData(info.mod).allowCyberGrindSubmission)
                     UKAPI.RemoveDisableCyberGrindReason(info.modName);

--- a/UK Mod Manager/UltraModManager.csproj
+++ b/UK Mod Manager/UltraModManager.csproj
@@ -69,7 +69,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ManagedDir)\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" />
+    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"/>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ManagedDir)\UnityEngine.UI.dll</HintPath>
@@ -108,6 +108,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="API\UKDependency.cs" />
     <Compile Include="Harmony Patches\Cybergrind Patches.cs" />
     <Compile Include="Harmony Patches\Mod UI Patches.cs" />
     <Compile Include="ModInformation.cs" />
@@ -130,7 +131,7 @@
     <BepInExPluginsDir>$(BepInExRootDir)/plugins/</BepInExPluginsDir>
   </PropertyGroup>
   <ItemGroup>
-    <ModDlls Include="$(OutDir)/$(AssemblyName).dll" />
+    <ModDlls Include="bin\Debug\/UMM.dll" />
   </ItemGroup>
   <Target Name="WarnBeforeBuild" BeforeTargets="BeforeBuild">
     <Error Condition="!Exists($(ULTRAKILLPath))" Text="ULTRAKILLPath not set, create a .csproj.user file that sets this property to compile" />

--- a/UK Mod Manager/UltraModManager.csproj
+++ b/UK Mod Manager/UltraModManager.csproj
@@ -69,7 +69,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ManagedDir)\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"/>
+    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" />
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(ManagedDir)\UnityEngine.UI.dll</HintPath>

--- a/UK Mod Manager/UltraModManager.csproj
+++ b/UK Mod Manager/UltraModManager.csproj
@@ -131,7 +131,7 @@
     <BepInExPluginsDir>$(BepInExRootDir)/plugins/</BepInExPluginsDir>
   </PropertyGroup>
   <ItemGroup>
-    <ModDlls Include="bin\Debug\/UMM.dll" />
+    <ModDlls Include="$(OutDir)/$(AssemblyName).dll" />
   </ItemGroup>
   <Target Name="WarnBeforeBuild" BeforeTargets="BeforeBuild">
     <Error Condition="!Exists($(ULTRAKILLPath))" Text="ULTRAKILLPath not set, create a .csproj.user file that sets this property to compile" />


### PR DESCRIPTION
Changed the mod dependency system to work using attributes, calling `LoadMod()` recursively on dependencies. LoadMod now checks if a mod is already loaded, and returns if it is. Skips loading a mod if the required dependency is missing or below the minimum version, logging an error stating either the GUID of the missing mod or the current and minimum versions.
UKPlugin now has a `GUID` field, and the `modVersion` field has been changed to a `Version` type instead of `string`. While this does break every mod until they are updated to include a GUID, this provides each mod a more code-friendly identifier, such as is used in the dependency system.