### PR TITLE
Changed mod dependency system, works similar to BepInEx's system

### DIFF
--- a/UK Mod Manager/API/UKAPI.cs
+++ b/UK Mod Manager/API/UKAPI.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using UMM.Loader;
 using Newtonsoft.Json;
 using UnityEngine.SceneManagement;
+using System.Linq;
 
 namespace UMM
 {
@@ -31,12 +32,12 @@ namespace UMM
         /// <summary>
         /// Returns a clone of all found <see cref="ModInformation"/> instances.
         /// </summary>
-        public static ModInformation[] AllModInfoClone => UltraModManager.foundMods.ToArray().Clone() as ModInformation[];
+        public static Dictionary<string, ModInformation> AllModInfoClone => UltraModManager.foundMods.ToDictionary(entry => entry.Key, entry => entry.Value);
 
         /// <summary>
         /// Returns a clone of all loaded <see cref="ModInformation"/> instances.
         /// </summary>
-        public static ModInformation[] AllLoadedModInfoClone => UltraModManager.allLoadedMods.ToArray().Clone() as ModInformation[];
+        public static Dictionary<string, ModInformation> AllLoadedModInfoClone => UltraModManager.allLoadedMods.ToDictionary(entry => entry.Key, entry => entry.Value);
 
         /// <summary>
         /// Initializes the API by loading the save file and common asset bundle
@@ -141,10 +142,10 @@ namespace UMM
         }
 
         [Obsolete("Use AllModInfoClone instead.")]
-        public static ModInformation[] GetAllModInformation() => AllModInfoClone;
+        public static Dictionary<string, ModInformation> GetAllModInformation() => AllModInfoClone;
 
         [Obsolete("Use AllLoadedModInfoClone instead.")]
-        public static ModInformation[] GetAllLoadedModInformation() => AllLoadedModInfoClone;
+        public static Dictionary<string, ModInformation> GetAllLoadedModInformation() => AllLoadedModInfoClone;
 
         /// <summary>
         /// Restarts Ultrakill

--- a/UK Mod Manager/API/UKDependency.cs
+++ b/UK Mod Manager/API/UKDependency.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace UMM
+{
+    public class UKDependency : Attribute
+    {
+        public string GUID;
+        public Version MinimumVersion;
+
+        public UKDependency(string GUID, string MinimumVersion)
+        {
+            this.GUID = GUID;
+            this.MinimumVersion = Version.Parse(MinimumVersion);
+        }
+    }
+}

--- a/UK Mod Manager/API/UKPlugin.cs
+++ b/UK Mod Manager/API/UKPlugin.cs
@@ -4,14 +4,16 @@ namespace UMM
 {
     public class UKPlugin : Attribute
     {
+        public string GUID { get; }
         public string name { get; }
         public string version { get; }
         public string description { get; }
         public bool allowCyberGrindSubmission { get; }
         public bool unloadingSupported { get; }
 
-        public UKPlugin(string name, string version, string description, bool allowCyberGrindSubmission, bool supportsUnloading)
+        public UKPlugin(string GUID, string name, string version, string description, bool allowCyberGrindSubmission, bool supportsUnloading)
         {
+            this.GUID = GUID;
             this.name = name;
             this.version = version;
             this.description = description;

--- a/UK Mod Manager/Harmony Patches/Mod UI Patches.cs
+++ b/UK Mod Manager/Harmony Patches/Mod UI Patches.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using UMM.Loader;
 using UnityEngine.EventSystems;
+using System.Linq;
 
 namespace UMM.HarmonyPatches
 {
@@ -96,7 +97,7 @@ namespace UMM.HarmonyPatches
                 GameObject.Destroy(hoverText.GetComponent<Button>());
                 hoverText.SetActive(false);
 
-                ModInformation[] information = UKAPI.AllModInfoClone;
+                ModInformation[] information = UKAPI.AllModInfoClone.Values.ToArray();
                 if (information.Length > 0)
                 {
                     Array.Sort(information);

--- a/UK Mod Manager/Properties/AssemblyInfo.cs
+++ b/UK Mod Manager/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("UK Sound Replacement")]
+[assembly: AssemblyTitle("UltraModManager")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("UK Sound Replacement")]
+[assembly: AssemblyProduct("UltraModManager")]
 [assembly: AssemblyCopyright("Copyright ©  2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/UK Mod Manager/UltraModManager.cs
+++ b/UK Mod Manager/UltraModManager.cs
@@ -137,14 +137,14 @@ namespace UMM.Loader
                     else
                     {
                         info.UnLoadThisMod();
-                        Debug.LogError($"Required dependency ({foundMods[dependency.GUID].modName}, version {foundMods[dependency.GUID].modVersion}) did not meet version requirements of {info.modName} (minimum version {dependency.MinimumVersion})");
+                        Plugin.logger.LogWarning($"Required dependency ({foundMods[dependency.GUID].modName}, version {foundMods[dependency.GUID].modVersion}) did not meet version requirements of {info.modName} (minimum version {dependency.MinimumVersion})");
                         return;
                     }
                 }
                 else
                 {
                     info.UnLoadThisMod();
-                    Debug.LogError($"Required dependency ({dependency.GUID}) of {info.modName} not found.");
+                    Plugin.logger.LogWarning($"Required dependency ({dependency.GUID}) of {info.modName} not found.");
                     return;
                 }
             }

--- a/UK Mod Manager/UltraModManager.csproj
+++ b/UK Mod Manager/UltraModManager.csproj
@@ -108,6 +108,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="API\UKDependency.cs" />
     <Compile Include="Harmony Patches\Cybergrind Patches.cs" />
     <Compile Include="Harmony Patches\Mod UI Patches.cs" />
     <Compile Include="ModInformation.cs" />


### PR DESCRIPTION
Changed the mod dependency system to work using attributes, calling `LoadMod()` recursively on dependencies. LoadMod now checks if a mod is already loaded, and returns if it is. Skips loading a mod if the required dependency is missing or below the minimum version, logging an error stating either the GUID of the missing mod or the current and minimum versions.
UKPlugin now has a `GUID` field, and the `modVersion` field has been changed to a `Version` type instead of `string`. While this does break every mod until they are updated to include a GUID, this provides each mod a more code-friendly identifier, such as is used in the dependency system.

Adjusted onto the Dev branch instead of master.