### PR TITLE
Make File Paths Platform Agnostic

### DIFF
--- a/UK Mod Manager/API/UKAPI.cs
+++ b/UK Mod Manager/API/UKAPI.cs
@@ -268,7 +268,7 @@ namespace UMM
             //Plugin.logger.LogMessage("Path is \"" + Environment.CurrentDirectory + "\\BepInEx\\plugins\\UMM\\UltrakillRestarter.exe\"");
             //string strCmdText;
             //strCmdText = "/K \"" + Environment.CurrentDirectory + "\\BepInEx\\plugins\\UMM\\Ultrakill Restarter.exe\""/* + System.Diagnostics.Process.GetCurrentProcess().Id.ToString() + "\""*/;
-            ////strCmdText = "/K \"" + Environment.CurrentDirectory + "\\ULTRAKILL.exe\"";
+            ////strCmdText = "/K \"" + Environment.CurrentDirectory + "ULTRAKILL.exe\"";
             //System.Diagnostics.Process.Start("CMD.exe", strCmdText);
 
             //var psi = new System.Diagnostics.ProcessStartInfo
@@ -288,8 +288,10 @@ namespace UMM
 
             internal static void LoadData()
             {
+            	OperatingSystem os = Environment.OSVersion;
+            	PlatformID     pid = os.Platform;
                 string path = Assembly.GetExecutingAssembly().Location;
-                path = path.Substring(0, path.LastIndexOf("\\")) + "\\persistent mod data.json";
+                path = path.Substring(0, path.LastIndexOf(Path.DirectorySeparatorChar)) + Path.DirectorySeparatorChar + "persistent mod data.json";
                 Plugin.logger.LogInfo("Trying to load persistent mod data.json from " + path);
                 SaveFile = new FileInfo(path);
                 if (SaveFile.Exists)

--- a/UK Mod Manager/UltraModManager.cs
+++ b/UK Mod Manager/UltraModManager.cs
@@ -13,7 +13,7 @@ namespace UMM.Loader
 {
     public static class UltraModManager
     {
-        public static DirectoryInfo modsDirectory = new DirectoryInfo(Path.Combine(BepInEx.Paths.BepInExRootPath, "UMM Mods\\"));
+        public static DirectoryInfo modsDirectory = new DirectoryInfo(Path.Combine(BepInEx.Paths.BepInExRootPath, "UMM Mods" + Path.DirectorySeparatorChar));
         public static Dictionary<string, ModInformation> foundMods = new Dictionary<string, ModInformation>();
         public static Dictionary<string, ModInformation> allLoadedMods = new Dictionary<string, ModInformation>();
         public static bool outdated { get; internal set; } = false;
@@ -64,7 +64,7 @@ namespace UMM.Loader
 
         public static void LoadFromAssembly(FileInfo fInfo)
         {
-            DirectoryInfo dInfo = new DirectoryInfo(fInfo.DirectoryName + "\\dependencies");
+            DirectoryInfo dInfo = new DirectoryInfo(fInfo.DirectoryName + Path.DirectorySeparatorChar + "dependencies");
             if (dInfo.Exists) // this solution is a hack i am well aware
             {
                 foreach (FileInfo info in dInfo.GetFiles("*.dll", SearchOption.AllDirectories))
@@ -82,7 +82,7 @@ namespace UMM.Loader
                         info = new ModInformation(type, ModInformation.ModType.BepInPlugin, fInfo.DirectoryName);
                     else
                         continue;
-                    FileInfo iconInfo = new FileInfo(Path.Combine(fInfo.DirectoryName + "\\" + "icon.png"));
+                    FileInfo iconInfo = new FileInfo(Path.Combine(fInfo.DirectoryName + Path.DirectorySeparatorChar + "icon.png"));
                     if (iconInfo.Exists)
                         Plugin.instance.StartCoroutine(GetModImage(iconInfo, info));
                     Plugin.logger.LogInfo("Adding mod info " + fInfo.FullName + " " + type.Name);

--- a/UK Mod Manager/UltraModManager.cs
+++ b/UK Mod Manager/UltraModManager.cs
@@ -13,7 +13,7 @@ namespace UMM.Loader
 {
     public static class UltraModManager
     {
-        public static DirectoryInfo modsDirectory = new DirectoryInfo(Path.Combine(BepInEx.Paths.BepInExRootPath, "UMM Mods" + Path.DirectorySeparatorChar));
+        public static DirectoryInfo modsDirectory = new DirectoryInfo(Path.Combine(BepInEx.Paths.BepInExRootPath, "UMM Mods"));
         public static Dictionary<string, ModInformation> foundMods = new Dictionary<string, ModInformation>();
         public static Dictionary<string, ModInformation> allLoadedMods = new Dictionary<string, ModInformation>();
         public static bool outdated { get; internal set; } = false;


### PR DESCRIPTION
Allows the plugin to work correctly in all versions of BepInEx, including the Unix version. This allows people using the unofficial platform porting method to play the game access to UMM.

Forked from the "no error spam on open" PR.

(I installed the mods incorrectly, hence why there is no metadata.)
![20230505_16h35m13s_grim](https://user-images.githubusercontent.com/61166135/236572744-bce3a917-75d0-46a3-a2a5-62a87dfdd987.png)
