### PR TITLE
Disable "RESTART" button on UNIX

### DIFF
--- a/UK Mod Manager/API/UKAPI.cs
+++ b/UK Mod Manager/API/UKAPI.cs
@@ -257,12 +257,12 @@ namespace UMM
             Application.Quit();
 
             // Sanity check, in case we restart on UNIX
-			string restartURL = (Application.platform == RuntimePlatform.WindowsPlayer) ? @"steam://run/1229490" : "https://pbs.twimg.com/profile_images/1671400524082565120/BgbMpge0_400x400.jpg";
-			string restartMessage = (Application.platform == RuntimePlatform.WindowsPlayer) ? "Restarting Ultrakill!" : "Restarting not supported on UNIX.";
+	    string restartURL = (Application.platform == RuntimePlatform.WindowsPlayer) ? @"steam://run/1229490" : "https://pbs.twimg.com/profile_images/1671400524082565120/BgbMpge0_400x400.jpg";
+	    string restartMessage = (Application.platform == RuntimePlatform.WindowsPlayer) ? "Restarting Ultrakill!" : "Restarting not supported on UNIX.";
 
             Plugin.logger.LogMessage(restartMessage);
-       		var psi = new System.Diagnostics.ProcessStartInfo
-       		{
+       	    var psi = new System.Diagnostics.ProcessStartInfo
+       	    {
                 FileName = restartURL,
                 UseShellExecute = true,
                 WindowStyle = System.Diagnostics.ProcessWindowStyle.Minimized

--- a/UK Mod Manager/API/UKAPI.cs
+++ b/UK Mod Manager/API/UKAPI.cs
@@ -255,16 +255,19 @@ namespace UMM
         public static void Restart() // thanks https://gitlab.com/vtolvr-mods/ModLoader/-/blob/release/Launcher/Program.cs
         {
             Application.Quit();
-            Plugin.logger.LogMessage("Restarting Ultrakill!");
 
-            var psi = new System.Diagnostics.ProcessStartInfo
-            {
-                FileName = @"steam://run/1229490",
+            // Sanity check, in case we restart on UNIX
+			string restartURL = (Application.platform == RuntimePlatform.WindowsPlayer) ? @"steam://run/1229490" : "https://pbs.twimg.com/profile_images/1671400524082565120/BgbMpge0_400x400.jpg";
+			string restartMessage = (Application.platform == RuntimePlatform.WindowsPlayer) ? "Restarting Ultrakill!" : "Restarting not supported on UNIX.";
+
+            Plugin.logger.LogMessage(restartMessage);
+       		var psi = new System.Diagnostics.ProcessStartInfo
+       		{
+                FileName = restartURL,
                 UseShellExecute = true,
                 WindowStyle = System.Diagnostics.ProcessWindowStyle.Minimized
             };
             System.Diagnostics.Process.Start(psi);
-
             //Plugin.logger.LogMessage("Path is \"" + Environment.CurrentDirectory + "\\BepInEx\\plugins\\UMM\\UltrakillRestarter.exe\"");
             //string strCmdText;
             //strCmdText = "/K \"" + Environment.CurrentDirectory + "\\BepInEx\\plugins\\UMM\\Ultrakill Restarter.exe\""/* + System.Diagnostics.Process.GetCurrentProcess().Id.ToString() + "\""*/;

--- a/UK Mod Manager/Harmony Patches/Mod UI Patches.cs
+++ b/UK Mod Manager/Harmony Patches/Mod UI Patches.cs
@@ -282,9 +282,12 @@ namespace UMM.HarmonyPatches
                     modsMenu.SetActive(true);
                 });
                 newModsButton.SetActive(true);
-
                 Transform quitButton = __instance.pauseMenu.transform.Find("Quit");
-                Halve(quitButton, true);
+                // Only resize QUIT button on Windows
+                if (Application.platform == RuntimePlatform.WindowsPlayer)
+                {
+                	Halve(quitButton, true);
+                }
 
                 GameObject restartButton = GameObject.Instantiate(__instance.pauseMenu.transform.Find("Continue").gameObject, __instance.pauseMenu.transform, true);
                 restartButton.SetActive(false);
@@ -295,7 +298,11 @@ namespace UMM.HarmonyPatches
                 });
                 restartButton.transform.localPosition = new Vector3(0, quitButton.localPosition.y, 0);
                 restartButton.GetComponentInChildren<Text>(true).text = "RESTART";
-                restartButton.SetActive(true);
+                // Only display RESTART button on Windows
+                if (Application.platform == RuntimePlatform.WindowsPlayer)
+                {
+                	restartButton.SetActive(true);
+                }
                 Halve(restartButton.transform, false);
             }
 

--- a/UK Mod Manager/Harmony Patches/Mod UI Patches.cs
+++ b/UK Mod Manager/Harmony Patches/Mod UI Patches.cs
@@ -288,7 +288,6 @@ namespace UMM.HarmonyPatches
                 {
                 	Halve(quitButton, true);
                 }
-
                 GameObject restartButton = GameObject.Instantiate(__instance.pauseMenu.transform.Find("Continue").gameObject, __instance.pauseMenu.transform, true);
                 restartButton.SetActive(false);
                 Button.ButtonClickedEvent restartButtonEvent = restartButton.GetComponent<Button>().onClick = new Button.ButtonClickedEvent(); // I have no memory of writing this, when did this get here?


### PR DESCRIPTION
As the title describes. This PR removes the "RESTART" button on the title screen when playing on non-Windows platforms, for the following reasons:

- On Linux, the xdg-mime handling for Steam URLs in Firefox is broken.
- On MacOS, you can't use Steam to launch the game.

Also added a sanity check in case someone *does* manage to restart on UNIX. Tested on Windows 10 LTSC 2021, and Arch Linux.